### PR TITLE
Pre-generate static HTML and a styled noscript message for scriptless browsing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/node:12.14
+      - image: circleci/node:12.14-browsers
     steps:
       - checkout
       - run: npm run release

--- a/packages/website/package-lock.json
+++ b/packages/website/package-lock.json
@@ -1719,8 +1719,7 @@
 		"@types/node": {
 			"version": "13.1.0",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-13.1.0.tgz",
-			"integrity": "sha512-zwrxviZS08kRX40nqBrmERElF2vpw4IUTd5khkhBTfFH8AOaeoLVx48EC4+ZzS2/Iga7NevncqnsUSYjM4OWYA==",
-			"dev": true
+			"integrity": "sha512-zwrxviZS08kRX40nqBrmERElF2vpw4IUTd5khkhBTfFH8AOaeoLVx48EC4+ZzS2/Iga7NevncqnsUSYjM4OWYA=="
 		},
 		"@types/parse-json": {
 			"version": "4.0.0",
@@ -2028,7 +2027,6 @@
 			"version": "1.3.7",
 			"resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.7.tgz",
 			"integrity": "sha512-Il80Qs2WjYlJIBNzNkK6KYqlVMTbZLXgHx2oT0pU/fjRHyEp+PEfEPY0R3WCwAGVOtauxh1hOxNgIf5bv7dQpA==",
-			"dev": true,
 			"requires": {
 				"mime-types": "~2.1.24",
 				"negotiator": "0.6.2"
@@ -2102,6 +2100,14 @@
 			"resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.13.tgz",
 			"integrity": "sha512-fERNJX8sOXfel6qCBCMPvZLzENBEhZTzKqg6vrOW5pvoEaQuJhRU4ndTAh6lHOxn1I6jnz2NHra56ZODM751uw==",
 			"dev": true
+		},
+		"agent-base": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.3.0.tgz",
+			"integrity": "sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==",
+			"requires": {
+				"es6-promisify": "^5.0.0"
+			}
 		},
 		"aggregate-error": {
 			"version": "3.0.1",
@@ -2425,8 +2431,7 @@
 		"async-limiter": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
-			"integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==",
-			"dev": true
+			"integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ=="
 		},
 		"asynckit": {
 			"version": "0.4.0",
@@ -2931,8 +2936,7 @@
 		"balanced-match": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-			"dev": true
+			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
 		},
 		"base": {
 			"version": "0.11.2",
@@ -3123,14 +3127,12 @@
 		"boolbase": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
-			"integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24=",
-			"dev": true
+			"integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24="
 		},
 		"brace-expansion": {
 			"version": "1.1.11",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
 			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-			"dev": true,
 			"requires": {
 				"balanced-match": "^1.0.0",
 				"concat-map": "0.0.1"
@@ -3304,8 +3306,7 @@
 		"buffer-from": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
-			"integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
-			"dev": true
+			"integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
 		},
 		"buffer-indexof": {
 			"version": "1.1.1",
@@ -3328,8 +3329,7 @@
 		"bytes": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
-			"integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg=",
-			"dev": true
+			"integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg="
 		},
 		"cacache": {
 			"version": "13.0.1",
@@ -3419,7 +3419,6 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/camel-case/-/camel-case-3.0.0.tgz",
 			"integrity": "sha1-yjw2iKTpzzpM2nd9xNy8cTJJz3M=",
-			"dev": true,
 			"requires": {
 				"no-case": "^2.2.0",
 				"upper-case": "^1.1.1"
@@ -3527,6 +3526,68 @@
 			"resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
 			"integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
 			"dev": true
+		},
+		"cheerio": {
+			"version": "1.0.0-rc.2",
+			"resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.2.tgz",
+			"integrity": "sha1-S59TqBsn5NXawxwP/Qz6A8xoMNs=",
+			"requires": {
+				"css-select": "~1.2.0",
+				"dom-serializer": "~0.1.0",
+				"entities": "~1.1.1",
+				"htmlparser2": "^3.9.1",
+				"lodash": "^4.15.0",
+				"parse5": "^3.0.1"
+			},
+			"dependencies": {
+				"css-select": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
+					"integrity": "sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=",
+					"requires": {
+						"boolbase": "~1.0.0",
+						"css-what": "2.1",
+						"domutils": "1.5.1",
+						"nth-check": "~1.0.1"
+					}
+				},
+				"css-what": {
+					"version": "2.1.3",
+					"resolved": "https://registry.npmjs.org/css-what/-/css-what-2.1.3.tgz",
+					"integrity": "sha512-a+EPoD+uZiNfh+5fxw2nO9QwFa6nJe2Or35fGY6Ipw1R3R4AGz1d1TEZrCegvw2YTmZ0jXirGYlzxxpYSHwpEg=="
+				},
+				"dom-serializer": {
+					"version": "0.1.1",
+					"resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.1.tgz",
+					"integrity": "sha512-l0IU0pPzLWSHBcieZbpOKgkIn3ts3vAh7ZuFyXNwJxJXk/c4Gwj9xaTJwIDVQCXawWD0qb3IzMGH5rglQaO0XA==",
+					"requires": {
+						"domelementtype": "^1.3.0",
+						"entities": "^1.1.1"
+					}
+				},
+				"domutils": {
+					"version": "1.5.1",
+					"resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
+					"integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
+					"requires": {
+						"dom-serializer": "0",
+						"domelementtype": "1"
+					}
+				},
+				"entities": {
+					"version": "1.1.2",
+					"resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
+					"integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w=="
+				},
+				"parse5": {
+					"version": "3.0.3",
+					"resolved": "https://registry.npmjs.org/parse5/-/parse5-3.0.3.tgz",
+					"integrity": "sha512-rgO9Zg5LLLkfJF9E6CCmXlSE4UVceloys8JrFqCcHloC3usd/kJCyPDwH2SOlzix2j3xaP9sUX3e8+kvkuleAA==",
+					"requires": {
+						"@types/node": "*"
+					}
+				}
+			}
 		},
 		"chokidar": {
 			"version": "2.1.8",
@@ -4187,7 +4248,6 @@
 			"version": "4.2.1",
 			"resolved": "https://registry.npmjs.org/clean-css/-/clean-css-4.2.1.tgz",
 			"integrity": "sha512-4ZxI6dy4lrY6FHzfiy1aEOXgu4LIsW2MhwG0VBKdcoGoH/XLFgaHSdLTGr4O8Be6A8r3MOphEiI8Gc1n0ecf3g==",
-			"dev": true,
 			"requires": {
 				"source-map": "~0.6.0"
 			},
@@ -4195,8 +4255,7 @@
 				"source-map": {
 					"version": "0.6.1",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
 				}
 			}
 		},
@@ -4464,14 +4523,12 @@
 		"concat-map": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-			"dev": true
+			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
 		},
 		"concat-stream": {
 			"version": "1.6.2",
 			"resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
 			"integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
-			"dev": true,
 			"requires": {
 				"buffer-from": "^1.0.0",
 				"inherits": "^2.0.3",
@@ -4483,7 +4540,6 @@
 					"version": "2.3.6",
 					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
 					"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
-					"dev": true,
 					"requires": {
 						"core-util-is": "~1.0.0",
 						"inherits": "~2.0.3",
@@ -4538,8 +4594,7 @@
 		"content-type": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
-			"integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
-			"dev": true
+			"integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
 		},
 		"convert-source-map": {
 			"version": "1.7.0",
@@ -4558,8 +4613,7 @@
 		"cookie-signature": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
-			"integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw=",
-			"dev": true
+			"integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
 		},
 		"copy-concurrently": {
 			"version": "1.0.5",
@@ -4614,8 +4668,7 @@
 		"core-util-is": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-			"dev": true
+			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
 		},
 		"cosmiconfig": {
 			"version": "5.2.1",
@@ -5064,7 +5117,6 @@
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
 			"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-			"dev": true,
 			"requires": {
 				"ms": "^2.1.1"
 			}
@@ -5226,8 +5278,7 @@
 		"depd": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
-			"integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
-			"dev": true
+			"integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak="
 		},
 		"des.js": {
 			"version": "1.0.1",
@@ -5242,8 +5293,7 @@
 		"destroy": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
-			"integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=",
-			"dev": true
+			"integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
 		},
 		"detect-newline": {
 			"version": "2.1.0",
@@ -5358,7 +5408,6 @@
 			"version": "0.2.2",
 			"resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.2.2.tgz",
 			"integrity": "sha512-2/xPb3ORsQ42nHYiSunXkDjPLBaEj/xTwUO4B7XCZQTRk7EBtTOPaygh10YAAh2OI1Qrp6NWfpAhzswj0ydt9g==",
-			"dev": true,
 			"requires": {
 				"domelementtype": "^2.0.1",
 				"entities": "^2.0.0"
@@ -5367,8 +5416,7 @@
 				"domelementtype": {
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.0.1.tgz",
-					"integrity": "sha512-5HOHUDsYZWV8FGWN0Njbr/Rn7f/eWSQi1v7+HsUVwXgn8nWWlL64zKDkS0n8ZmQ3mlWOMuXOnR+7Nx/5tMO5AQ==",
-					"dev": true
+					"integrity": "sha512-5HOHUDsYZWV8FGWN0Njbr/Rn7f/eWSQi1v7+HsUVwXgn8nWWlL64zKDkS0n8ZmQ3mlWOMuXOnR+7Nx/5tMO5AQ=="
 				}
 			}
 		},
@@ -5381,8 +5429,7 @@
 		"domelementtype": {
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
-			"integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w==",
-			"dev": true
+			"integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w=="
 		},
 		"domexception": {
 			"version": "1.0.1",
@@ -5397,7 +5444,6 @@
 			"version": "2.4.2",
 			"resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.2.tgz",
 			"integrity": "sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==",
-			"dev": true,
 			"requires": {
 				"domelementtype": "1"
 			}
@@ -5406,7 +5452,6 @@
 			"version": "1.7.0",
 			"resolved": "https://registry.npmjs.org/domutils/-/domutils-1.7.0.tgz",
 			"integrity": "sha512-Lgd2XcJ/NjEw+7tFvfKxOzCYKZsdct5lczQ2ZaQY8Djz7pfAD3Gbp8ySJWtreII/vDlMVmxwa6pHmdxIYgttDg==",
-			"dev": true,
 			"requires": {
 				"dom-serializer": "0",
 				"domelementtype": "1"
@@ -5481,8 +5526,7 @@
 		"ee-first": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
-			"integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=",
-			"dev": true
+			"integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
 		},
 		"electron-to-chromium": {
 			"version": "1.3.322",
@@ -5526,21 +5570,18 @@
 				"create-emotion": "^10.0.27"
 			}
 		},
-		"emotion-theming": {
-			"version": "10.0.27",
-			"resolved": "https://registry.npmjs.org/emotion-theming/-/emotion-theming-10.0.27.tgz",
-			"integrity": "sha512-MlF1yu/gYh8u+sLUqA0YuA9JX0P4Hb69WlKc/9OLo+WCXuX6sy/KoIa+qJimgmr2dWqnypYKYPX37esjDBbhdw==",
-			"requires": {
-				"@babel/runtime": "^7.5.5",
-				"@emotion/weak-memoize": "0.2.5",
-				"hoist-non-react-statics": "^3.3.0"
-			}
-		},
 		"encodeurl": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
-			"integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
-			"dev": true
+			"integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
+		},
+		"encoding": {
+			"version": "0.1.12",
+			"resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
+			"integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
+			"requires": {
+				"iconv-lite": "~0.4.13"
+			}
 		},
 		"end-of-stream": {
 			"version": "1.4.4",
@@ -5592,8 +5633,7 @@
 		"entities": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/entities/-/entities-2.0.0.tgz",
-			"integrity": "sha512-D9f7V0JSRwIxlRI2mjMqufDrRDnx8p+eEOz7aUM9SuvF8gsBzra0/6tbjl1m8eQHrZlYj6PxqE00hZ1SAIKPLw==",
-			"dev": true
+			"integrity": "sha512-D9f7V0JSRwIxlRI2mjMqufDrRDnx8p+eEOz7aUM9SuvF8gsBzra0/6tbjl1m8eQHrZlYj6PxqE00hZ1SAIKPLw=="
 		},
 		"errno": {
 			"version": "0.1.7",
@@ -5664,6 +5704,19 @@
 				"es6-symbol": "^3.1.1"
 			}
 		},
+		"es6-promise": {
+			"version": "4.2.8",
+			"resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
+			"integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w=="
+		},
+		"es6-promisify": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+			"integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
+			"requires": {
+				"es6-promise": "^4.0.3"
+			}
+		},
 		"es6-symbol": {
 			"version": "3.1.3",
 			"resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.3.tgz",
@@ -5677,8 +5730,7 @@
 		"escape-html": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
-			"integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=",
-			"dev": true
+			"integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
 		},
 		"escape-string-regexp": {
 			"version": "1.0.5",
@@ -6218,8 +6270,7 @@
 		"etag": {
 			"version": "1.8.1",
 			"resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
-			"integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
-			"dev": true
+			"integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
 		},
 		"eventemitter3": {
 			"version": "4.0.0",
@@ -6410,6 +6461,11 @@
 				}
 			}
 		},
+		"express-history-api-fallback": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/express-history-api-fallback/-/express-history-api-fallback-2.2.1.tgz",
+			"integrity": "sha1-OirSf3vryQ/FM9EQ18bYMJe80Fc="
+		},
 		"ext": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/ext/-/ext-1.4.0.tgz",
@@ -6536,6 +6592,32 @@
 				}
 			}
 		},
+		"extract-zip": {
+			"version": "1.6.7",
+			"resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.6.7.tgz",
+			"integrity": "sha1-qEC0uK9kAyZMjbV/Txp0Mz74H+k=",
+			"requires": {
+				"concat-stream": "1.6.2",
+				"debug": "2.6.9",
+				"mkdirp": "0.5.1",
+				"yauzl": "2.4.1"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+				}
+			}
+		},
 		"extsprintf": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
@@ -6615,6 +6697,14 @@
 				"bser": "2.1.1"
 			}
 		},
+		"fd-slicer": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz",
+			"integrity": "sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=",
+			"requires": {
+				"pend": "~1.2.0"
+			}
+		},
 		"figgy-pudding": {
 			"version": "3.5.1",
 			"resolved": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.5.1.tgz",
@@ -6659,8 +6749,7 @@
 		"filesize": {
 			"version": "3.6.1",
 			"resolved": "https://registry.npmjs.org/filesize/-/filesize-3.6.1.tgz",
-			"integrity": "sha512-7KjR1vv6qnicaPMi1iiTcI85CyYwRO/PSFCu6SvqL8jN2Wjt/NIYQTFtFs7fSDCYOstUkEWIQGFUg5YZQfjlcg==",
-			"dev": true
+			"integrity": "sha512-7KjR1vv6qnicaPMi1iiTcI85CyYwRO/PSFCu6SvqL8jN2Wjt/NIYQTFtFs7fSDCYOstUkEWIQGFUg5YZQfjlcg=="
 		},
 		"fill-range": {
 			"version": "4.0.0",
@@ -6882,8 +6971,7 @@
 		"forwarded": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
-			"integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ=",
-			"dev": true
+			"integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ="
 		},
 		"fragment-cache": {
 			"version": "0.2.1",
@@ -6897,8 +6985,7 @@
 		"fresh": {
 			"version": "0.5.2",
 			"resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
-			"integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=",
-			"dev": true
+			"integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
 		},
 		"from2": {
 			"version": "2.3.0",
@@ -6985,8 +7072,7 @@
 		"fs.realpath": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-			"dev": true
+			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
 		},
 		"fsevents": {
 			"version": "2.1.2",
@@ -7047,7 +7133,6 @@
 			"version": "7.1.6",
 			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
 			"integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
-			"dev": true,
 			"requires": {
 				"fs.realpath": "^1.0.0",
 				"inflight": "^1.0.4",
@@ -7305,14 +7390,21 @@
 		"he": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
-			"integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
-			"dev": true
+			"integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw=="
 		},
 		"hex-color-regex": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/hex-color-regex/-/hex-color-regex-1.1.0.tgz",
 			"integrity": "sha512-l9sfDFsuqtOqKDsQdqrMRk0U85RZc0RtOR9yPI7mRVOa4FsR/BVnZ0shmQRM96Ji99kYZP/7hn1cedc1+ApsTQ==",
 			"dev": true
+		},
+		"highland": {
+			"version": "2.13.0",
+			"resolved": "https://registry.npmjs.org/highland/-/highland-2.13.0.tgz",
+			"integrity": "sha512-zGZBcgAHPY2Zf9VG9S5IrlcC7CH9ELioXVtp9T5bU2a4fP2zIsA+Y8pV/n/h2lMwbWMHTX0I0xN0ODJ3Pd3aBQ==",
+			"requires": {
+				"util-deprecate": "^1.0.2"
+			}
 		},
 		"hmac-drbg": {
 			"version": "1.0.1",
@@ -7323,14 +7415,6 @@
 				"hash.js": "^1.0.3",
 				"minimalistic-assert": "^1.0.0",
 				"minimalistic-crypto-utils": "^1.0.1"
-			}
-		},
-		"hoist-non-react-statics": {
-			"version": "3.3.1",
-			"resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz",
-			"integrity": "sha512-wbg3bpgA/ZqWrZuMOeJi8+SKMhr7X9TesL/rXMjTzh0p0JUBo3II8DHboYbuIXWRlttrUFxwcu/5kygrCw8fJw==",
-			"requires": {
-				"react-is": "^16.7.0"
 			}
 		},
 		"hosted-git-info": {
@@ -7405,7 +7489,6 @@
 			"version": "3.5.21",
 			"resolved": "https://registry.npmjs.org/html-minifier/-/html-minifier-3.5.21.tgz",
 			"integrity": "sha512-LKUKwuJDhxNa3uf/LPR/KVjm/l3rBqtYeCOAekvG8F1vItxMUpueGd94i/asDDr8/1u7InxzFA5EeGjhhG5mMA==",
-			"dev": true,
 			"requires": {
 				"camel-case": "3.0.x",
 				"clean-css": "4.2.x",
@@ -7419,8 +7502,7 @@
 				"commander": {
 					"version": "2.17.1",
 					"resolved": "https://registry.npmjs.org/commander/-/commander-2.17.1.tgz",
-					"integrity": "sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg==",
-					"dev": true
+					"integrity": "sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg=="
 				}
 			}
 		},
@@ -7442,7 +7524,6 @@
 			"version": "3.10.1",
 			"resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.10.1.tgz",
 			"integrity": "sha512-IgieNijUMbkDovyoKObU1DUhm1iwNYE/fuifEoEHfd1oZKZDaONBSkal7Y01shxsM49R4XaMdGez3WnF9UfiCQ==",
-			"dev": true,
 			"requires": {
 				"domelementtype": "^1.3.1",
 				"domhandler": "^2.3.0",
@@ -7455,8 +7536,7 @@
 				"entities": {
 					"version": "1.1.2",
 					"resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
-					"integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w==",
-					"dev": true
+					"integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w=="
 				}
 			}
 		},
@@ -7533,11 +7613,29 @@
 			"integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=",
 			"dev": true
 		},
+		"https-proxy-agent": {
+			"version": "2.2.4",
+			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.4.tgz",
+			"integrity": "sha512-OmvfoQ53WLjtA9HeYP9RNrWMJzzAz1JGaSFr1nijg0PVR1JaD/xbJq1mdEIIlxGpXp9eSe/O2LgU9DJmTPd0Eg==",
+			"requires": {
+				"agent-base": "^4.3.0",
+				"debug": "^3.1.0"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "3.2.6",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+					"integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+					"requires": {
+						"ms": "^2.1.1"
+					}
+				}
+			}
+		},
 		"iconv-lite": {
 			"version": "0.4.24",
 			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
 			"integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-			"dev": true,
 			"requires": {
 				"safer-buffer": ">= 2.1.2 < 3"
 			}
@@ -7650,7 +7748,6 @@
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
 			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-			"dev": true,
 			"requires": {
 				"once": "^1.3.0",
 				"wrappy": "1"
@@ -7659,8 +7756,7 @@
 		"inherits": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-			"dev": true
+			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
 		},
 		"ini": {
 			"version": "1.3.5",
@@ -7742,8 +7838,7 @@
 		"ipaddr.js": {
 			"version": "1.9.0",
 			"resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.0.tgz",
-			"integrity": "sha512-M4Sjn6N/+O6/IXSJseKqHoFc+5FdGJ22sXqnjTpdZweHK64MzEPAyQZyEU3R/KRv2GLoa7nNtg/C2Ev6m7z+eA==",
-			"dev": true
+			"integrity": "sha512-M4Sjn6N/+O6/IXSJseKqHoFc+5FdGJ22sXqnjTpdZweHK64MzEPAyQZyEU3R/KRv2GLoa7nNtg/C2Ev6m7z+eA=="
 		},
 		"is-absolute-url": {
 			"version": "2.1.0",
@@ -7978,8 +8073,7 @@
 		"is-stream": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-			"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
-			"dev": true
+			"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
 		},
 		"is-string": {
 			"version": "1.0.5",
@@ -8026,8 +8120,7 @@
 		"isarray": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-			"dev": true
+			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
 		},
 		"isexe": {
 			"version": "2.0.0",
@@ -8040,6 +8133,15 @@
 			"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
 			"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
 			"dev": true
+		},
+		"isomorphic-fetch": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
+			"integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
+			"requires": {
+				"node-fetch": "^1.0.1",
+				"whatwg-fetch": ">=0.10.0"
+			}
 		},
 		"isstream": {
 			"version": "0.1.2",
@@ -9897,8 +9999,7 @@
 		"lower-case": {
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/lower-case/-/lower-case-1.1.4.tgz",
-			"integrity": "sha1-miyr0bno4K6ZOkv31YdcOcQujqw=",
-			"dev": true
+			"integrity": "sha1-miyr0bno4K6ZOkv31YdcOcQujqw="
 		},
 		"lru-cache": {
 			"version": "5.1.1",
@@ -10000,8 +10101,7 @@
 		"media-typer": {
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
-			"integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
-			"dev": true
+			"integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
 		},
 		"mem": {
 			"version": "4.3.0",
@@ -10055,8 +10155,7 @@
 		"merge-descriptors": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
-			"integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=",
-			"dev": true
+			"integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E="
 		},
 		"merge-stream": {
 			"version": "2.0.0",
@@ -10073,8 +10172,7 @@
 		"methods": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
-			"integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=",
-			"dev": true
+			"integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
 		},
 		"microevent.ts": {
 			"version": "0.1.1",
@@ -10124,20 +10222,17 @@
 		"mime": {
 			"version": "2.4.4",
 			"resolved": "https://registry.npmjs.org/mime/-/mime-2.4.4.tgz",
-			"integrity": "sha512-LRxmNwziLPT828z+4YkNzloCFC2YM4wrB99k+AV5ZbEyfGNWfG8SO1FUXLmLDBSo89NrJZ4DIWeLjy1CHGhMGA==",
-			"dev": true
+			"integrity": "sha512-LRxmNwziLPT828z+4YkNzloCFC2YM4wrB99k+AV5ZbEyfGNWfG8SO1FUXLmLDBSo89NrJZ4DIWeLjy1CHGhMGA=="
 		},
 		"mime-db": {
 			"version": "1.42.0",
 			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.42.0.tgz",
-			"integrity": "sha512-UbfJCR4UAVRNgMpfImz05smAXK7+c+ZntjaA26ANtkXLlOe947Aag5zdIcKQULAiF9Cq4WxBi9jUs5zkA84bYQ==",
-			"dev": true
+			"integrity": "sha512-UbfJCR4UAVRNgMpfImz05smAXK7+c+ZntjaA26ANtkXLlOe947Aag5zdIcKQULAiF9Cq4WxBi9jUs5zkA84bYQ=="
 		},
 		"mime-types": {
 			"version": "2.1.25",
 			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.25.tgz",
 			"integrity": "sha512-5KhStqB5xpTAeGqKBAMgwaYMnQik7teQN4IAzC7npDv6kzeU6prfkR67bc87J1kWMPGkoaZSq1npmexMgkmEVg==",
-			"dev": true,
 			"requires": {
 				"mime-db": "1.42.0"
 			}
@@ -10173,6 +10268,54 @@
 				}
 			}
 		},
+		"minimalcss": {
+			"version": "0.8.1",
+			"resolved": "https://registry.npmjs.org/minimalcss/-/minimalcss-0.8.1.tgz",
+			"integrity": "sha512-a+kbRVvxz+oQf43pweflM38KvcvVuTvv3v6a8UgVbfS7E2rktSJSf8kfbGToSXgbiBDP83WTh8MWL6PdT9ljag==",
+			"requires": {
+				"cheerio": "1.0.0-rc.2",
+				"css-tree": "1.0.0-alpha.28",
+				"csso": "~3.5.0",
+				"filesize": "^3.5.11",
+				"minimist": "^1.2.0",
+				"puppeteer": "^1.8.0"
+			},
+			"dependencies": {
+				"css-tree": {
+					"version": "1.0.0-alpha.28",
+					"resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.0.0-alpha.28.tgz",
+					"integrity": "sha512-joNNW1gCp3qFFzj4St6zk+Wh/NBv0vM5YbEreZk0SD4S23S+1xBKb6cLDg2uj4P4k/GUMlIm6cKIDqIG+vdt0w==",
+					"requires": {
+						"mdn-data": "~1.1.0",
+						"source-map": "^0.5.3"
+					}
+				},
+				"csso": {
+					"version": "3.5.1",
+					"resolved": "https://registry.npmjs.org/csso/-/csso-3.5.1.tgz",
+					"integrity": "sha512-vrqULLffYU1Q2tLdJvaCYbONStnfkfimRxXNaGjxMldI0C7JPBC4rB1RyjhfdZ4m1frm8pM9uRPKH3d2knZ8gg==",
+					"requires": {
+						"css-tree": "1.0.0-alpha.29"
+					},
+					"dependencies": {
+						"css-tree": {
+							"version": "1.0.0-alpha.29",
+							"resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.0.0-alpha.29.tgz",
+							"integrity": "sha512-sRNb1XydwkW9IOci6iB2xmy8IGCj6r/fr+JWitvJ2JxQRPzN3T4AGGVWCMlVmVwM1gtgALJRmGIlWv5ppnGGkg==",
+							"requires": {
+								"mdn-data": "~1.1.0",
+								"source-map": "^0.5.3"
+							}
+						}
+					}
+				},
+				"mdn-data": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-1.1.4.tgz",
+					"integrity": "sha512-FSYbp3lyKjyj3E7fMl6rYvUdX0FBXaluGqlFoYESWQlyUTq8R+wp0rkFxoYFqZlHCvsUXGjyJmLQSnXToYhOSA=="
+				}
+			}
+		},
 		"minimalistic-assert": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
@@ -10189,7 +10332,6 @@
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
 			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-			"dev": true,
 			"requires": {
 				"brace-expansion": "^1.1.7"
 			}
@@ -10197,8 +10339,7 @@
 		"minimist": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-			"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-			"dev": true
+			"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
 		},
 		"minipass": {
 			"version": "3.1.1",
@@ -10297,7 +10438,6 @@
 			"version": "0.5.1",
 			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
 			"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-			"dev": true,
 			"requires": {
 				"minimist": "0.0.8"
 			},
@@ -10305,8 +10445,7 @@
 				"minimist": {
 					"version": "0.0.8",
 					"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-					"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-					"dev": true
+					"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
 				}
 			}
 		},
@@ -10327,8 +10466,7 @@
 		"ms": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-			"dev": true
+			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
 		},
 		"multicast-dns": {
 			"version": "6.2.3",
@@ -10395,8 +10533,7 @@
 		"negotiator": {
 			"version": "0.6.2",
 			"resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
-			"integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw==",
-			"dev": true
+			"integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw=="
 		},
 		"neo-async": {
 			"version": "2.6.1",
@@ -10420,9 +10557,17 @@
 			"version": "2.3.2",
 			"resolved": "https://registry.npmjs.org/no-case/-/no-case-2.3.2.tgz",
 			"integrity": "sha512-rmTZ9kz+f3rCvK2TD1Ue/oZlns7OGoIWP4fc3llxxRXlOkHKoWPPWJOfFYpITabSow43QJbRIoHQXtt10VldyQ==",
-			"dev": true,
 			"requires": {
 				"lower-case": "^1.1.1"
+			}
+		},
+		"node-fetch": {
+			"version": "1.7.3",
+			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
+			"integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+			"requires": {
+				"encoding": "^0.1.11",
+				"is-stream": "^1.0.1"
 			}
 		},
 		"node-forge": {
@@ -10628,7 +10773,6 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.2.tgz",
 			"integrity": "sha512-WeBOdju8SnzPN5vTUJYxYUxLeXpCaVP5i5e0LF8fg7WORF2Wd7wFX/pk0tYZk7s8T+J7VLy0Da6J1+wCT0AtHg==",
-			"dev": true,
 			"requires": {
 				"boolbase": "~1.0.0"
 			}
@@ -10800,7 +10944,6 @@
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
 			"integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
-			"dev": true,
 			"requires": {
 				"ee-first": "1.1.1"
 			}
@@ -10815,7 +10958,6 @@
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
 			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-			"dev": true,
 			"requires": {
 				"wrappy": "1"
 			}
@@ -11042,7 +11184,6 @@
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/param-case/-/param-case-2.1.1.tgz",
 			"integrity": "sha1-35T9jPZTHs915r75oIWPvHK+Ikc=",
-			"dev": true,
 			"requires": {
 				"no-case": "^2.2.0"
 			}
@@ -11095,8 +11236,7 @@
 		"parseurl": {
 			"version": "1.3.3",
 			"resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
-			"integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
-			"dev": true
+			"integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="
 		},
 		"pascalcase": {
 			"version": "0.1.1",
@@ -11125,8 +11265,7 @@
 		"path-is-absolute": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-			"dev": true
+			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
 		},
 		"path-is-inside": {
 			"version": "1.0.2",
@@ -11148,8 +11287,7 @@
 		"path-to-regexp": {
 			"version": "0.1.7",
 			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
-			"integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=",
-			"dev": true
+			"integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
 		},
 		"path-type": {
 			"version": "3.0.0",
@@ -11172,6 +11310,11 @@
 				"safe-buffer": "^5.0.1",
 				"sha.js": "^2.4.8"
 			}
+		},
+		"pend": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+			"integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA="
 		},
 		"performance-now": {
 			"version": "2.1.0",
@@ -12462,14 +12605,12 @@
 		"process-nextick-args": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-			"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-			"dev": true
+			"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
 		},
 		"progress": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
-			"integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
-			"dev": true
+			"integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA=="
 		},
 		"promise": {
 			"version": "8.0.3",
@@ -12510,11 +12651,15 @@
 			"version": "2.0.5",
 			"resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.5.tgz",
 			"integrity": "sha512-t/7RxHXPH6cJtP0pRG6smSr9QJidhB+3kXu0KgXnbGYMgzEnUxRQ4/LDdfOwZEMyIh3/xHb8PX3t+lfL9z+YVQ==",
-			"dev": true,
 			"requires": {
 				"forwarded": "~0.1.2",
 				"ipaddr.js": "1.9.0"
 			}
+		},
+		"proxy-from-env": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.0.0.tgz",
+			"integrity": "sha1-M8UDmPcOp+uW0h97gXYwpVeRx+4="
 		},
 		"prr": {
 			"version": "1.0.1",
@@ -12581,6 +12726,31 @@
 			"integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=",
 			"dev": true
 		},
+		"puppeteer": {
+			"version": "1.20.0",
+			"resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-1.20.0.tgz",
+			"integrity": "sha512-bt48RDBy2eIwZPrkgbcwHtb51mj2nKvHOPMaSH2IsWiv7lOG9k9zhaRzpDZafrk05ajMc3cu+lSQYYOfH2DkVQ==",
+			"requires": {
+				"debug": "^4.1.0",
+				"extract-zip": "^1.6.6",
+				"https-proxy-agent": "^2.2.1",
+				"mime": "^2.0.3",
+				"progress": "^2.0.1",
+				"proxy-from-env": "^1.0.0",
+				"rimraf": "^2.6.1",
+				"ws": "^6.1.0"
+			},
+			"dependencies": {
+				"ws": {
+					"version": "6.2.1",
+					"resolved": "https://registry.npmjs.org/ws/-/ws-6.2.1.tgz",
+					"integrity": "sha512-GIyAXC2cB7LjvpgMt9EKS2ldqr0MTrORaleiOno6TweZ6r3TKtoFQWay/2PceJ3RuBasOHzXNn5Lrw1X0bEjqA==",
+					"requires": {
+						"async-limiter": "~1.0.0"
+					}
+				}
+			}
+		},
 		"q": {
 			"version": "1.5.1",
 			"resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
@@ -12590,8 +12760,7 @@
 		"qs": {
 			"version": "6.5.2",
 			"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-			"integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
-			"dev": true
+			"integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
 		},
 		"query-string": {
 			"version": "4.3.4",
@@ -12652,8 +12821,7 @@
 		"range-parser": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
-			"integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
-			"dev": true
+			"integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="
 		},
 		"raw-body": {
 			"version": "2.4.0",
@@ -12947,6 +13115,202 @@
 				"workbox-webpack-plugin": "4.3.1"
 			}
 		},
+		"react-snap": {
+			"version": "1.23.0",
+			"resolved": "https://registry.npmjs.org/react-snap/-/react-snap-1.23.0.tgz",
+			"integrity": "sha512-spmg2maHSedLrn6QBAfLJkyMqeeffLTIs7h40pS1copW2xBrajx4HEAcanm+7IVGO6SYCPoGwvbU3U30UFN25g==",
+			"requires": {
+				"clean-css": "4.2.1",
+				"express": "4.16.4",
+				"express-history-api-fallback": "2.2.1",
+				"highland": "2.13.0",
+				"html-minifier": "3.5.21",
+				"minimalcss": "0.8.1",
+				"mkdirp": "0.5.1",
+				"puppeteer": "^1.8.0",
+				"serve-static": "1.13.2",
+				"sourcemapped-stacktrace-node": "2.1.8"
+			},
+			"dependencies": {
+				"array-flatten": {
+					"version": "1.1.1",
+					"resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+					"integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
+				},
+				"body-parser": {
+					"version": "1.18.3",
+					"resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.3.tgz",
+					"integrity": "sha1-WykhmP/dVTs6DyDe0FkrlWlVyLQ=",
+					"requires": {
+						"bytes": "3.0.0",
+						"content-type": "~1.0.4",
+						"debug": "2.6.9",
+						"depd": "~1.1.2",
+						"http-errors": "~1.6.3",
+						"iconv-lite": "0.4.23",
+						"on-finished": "~2.3.0",
+						"qs": "6.5.2",
+						"raw-body": "2.3.3",
+						"type-is": "~1.6.16"
+					}
+				},
+				"content-disposition": {
+					"version": "0.5.2",
+					"resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
+					"integrity": "sha1-DPaLud318r55YcOoUXjLhdunjLQ="
+				},
+				"cookie": {
+					"version": "0.3.1",
+					"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
+					"integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s="
+				},
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"express": {
+					"version": "4.16.4",
+					"resolved": "https://registry.npmjs.org/express/-/express-4.16.4.tgz",
+					"integrity": "sha512-j12Uuyb4FMrd/qQAm6uCHAkPtO8FDTRJZBDd5D2KOL2eLaz1yUNdUB/NOIyq0iU4q4cFarsUCrnFDPBcnksuOg==",
+					"requires": {
+						"accepts": "~1.3.5",
+						"array-flatten": "1.1.1",
+						"body-parser": "1.18.3",
+						"content-disposition": "0.5.2",
+						"content-type": "~1.0.4",
+						"cookie": "0.3.1",
+						"cookie-signature": "1.0.6",
+						"debug": "2.6.9",
+						"depd": "~1.1.2",
+						"encodeurl": "~1.0.2",
+						"escape-html": "~1.0.3",
+						"etag": "~1.8.1",
+						"finalhandler": "1.1.1",
+						"fresh": "0.5.2",
+						"merge-descriptors": "1.0.1",
+						"methods": "~1.1.2",
+						"on-finished": "~2.3.0",
+						"parseurl": "~1.3.2",
+						"path-to-regexp": "0.1.7",
+						"proxy-addr": "~2.0.4",
+						"qs": "6.5.2",
+						"range-parser": "~1.2.0",
+						"safe-buffer": "5.1.2",
+						"send": "0.16.2",
+						"serve-static": "1.13.2",
+						"setprototypeof": "1.1.0",
+						"statuses": "~1.4.0",
+						"type-is": "~1.6.16",
+						"utils-merge": "1.0.1",
+						"vary": "~1.1.2"
+					}
+				},
+				"finalhandler": {
+					"version": "1.1.1",
+					"resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
+					"integrity": "sha512-Y1GUDo39ez4aHAw7MysnUD5JzYX+WaIj8I57kO3aEPT1fFRL4sr7mjei97FgnwhAyyzRYmQZaTHb2+9uZ1dPtg==",
+					"requires": {
+						"debug": "2.6.9",
+						"encodeurl": "~1.0.2",
+						"escape-html": "~1.0.3",
+						"on-finished": "~2.3.0",
+						"parseurl": "~1.3.2",
+						"statuses": "~1.4.0",
+						"unpipe": "~1.0.0"
+					}
+				},
+				"http-errors": {
+					"version": "1.6.3",
+					"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
+					"integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
+					"requires": {
+						"depd": "~1.1.2",
+						"inherits": "2.0.3",
+						"setprototypeof": "1.1.0",
+						"statuses": ">= 1.4.0 < 2"
+					}
+				},
+				"iconv-lite": {
+					"version": "0.4.23",
+					"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
+					"integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
+					"requires": {
+						"safer-buffer": ">= 2.1.2 < 3"
+					}
+				},
+				"inherits": {
+					"version": "2.0.3",
+					"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+					"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+				},
+				"mime": {
+					"version": "1.4.1",
+					"resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
+					"integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ=="
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+				},
+				"raw-body": {
+					"version": "2.3.3",
+					"resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.3.tgz",
+					"integrity": "sha512-9esiElv1BrZoI3rCDuOuKCBRbuApGGaDPQfjSflGxdy4oyzqghxu6klEkkVIvBje+FF0BX9coEv8KqW6X/7njw==",
+					"requires": {
+						"bytes": "3.0.0",
+						"http-errors": "1.6.3",
+						"iconv-lite": "0.4.23",
+						"unpipe": "1.0.0"
+					}
+				},
+				"send": {
+					"version": "0.16.2",
+					"resolved": "https://registry.npmjs.org/send/-/send-0.16.2.tgz",
+					"integrity": "sha512-E64YFPUssFHEFBvpbbjr44NCLtI1AohxQ8ZSiJjQLskAdKuriYEP6VyGEsRDH8ScozGpkaX1BGvhanqCwkcEZw==",
+					"requires": {
+						"debug": "2.6.9",
+						"depd": "~1.1.2",
+						"destroy": "~1.0.4",
+						"encodeurl": "~1.0.2",
+						"escape-html": "~1.0.3",
+						"etag": "~1.8.1",
+						"fresh": "0.5.2",
+						"http-errors": "~1.6.2",
+						"mime": "1.4.1",
+						"ms": "2.0.0",
+						"on-finished": "~2.3.0",
+						"range-parser": "~1.2.0",
+						"statuses": "~1.4.0"
+					}
+				},
+				"serve-static": {
+					"version": "1.13.2",
+					"resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.2.tgz",
+					"integrity": "sha512-p/tdJrO4U387R9oMjb1oj7qSMaMfmOyd4j9hOFoxZe2baQszgHcSWjuya/CiT5kgZZKRudHNOA0pYXOl8rQ5nw==",
+					"requires": {
+						"encodeurl": "~1.0.2",
+						"escape-html": "~1.0.3",
+						"parseurl": "~1.3.2",
+						"send": "0.16.2"
+					}
+				},
+				"setprototypeof": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
+					"integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ=="
+				},
+				"statuses": {
+					"version": "1.4.0",
+					"resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
+					"integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew=="
+				}
+			}
+		},
 		"read-pkg": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
@@ -12972,7 +13336,6 @@
 			"version": "3.4.0",
 			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
 			"integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
-			"dev": true,
 			"requires": {
 				"inherits": "^2.0.3",
 				"string_decoder": "^1.1.1",
@@ -13126,8 +13489,7 @@
 		"relateurl": {
 			"version": "0.2.7",
 			"resolved": "https://registry.npmjs.org/relateurl/-/relateurl-0.2.7.tgz",
-			"integrity": "sha1-VNvzd+UUQKypCkzSdGANP/LYiKk=",
-			"dev": true
+			"integrity": "sha1-VNvzd+UUQKypCkzSdGANP/LYiKk="
 		},
 		"remove-trailing-separator": {
 			"version": "1.1.0",
@@ -13448,7 +13810,6 @@
 			"version": "2.6.3",
 			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
 			"integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
-			"dev": true,
 			"requires": {
 				"glob": "^7.1.3"
 			}
@@ -13513,8 +13874,7 @@
 		"safer-buffer": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-			"dev": true
+			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
 		},
 		"sane": {
 			"version": "4.1.0",
@@ -14140,6 +14500,23 @@
 			"integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
 			"dev": true
 		},
+		"sourcemapped-stacktrace-node": {
+			"version": "2.1.8",
+			"resolved": "https://registry.npmjs.org/sourcemapped-stacktrace-node/-/sourcemapped-stacktrace-node-2.1.8.tgz",
+			"integrity": "sha512-xQOqfT5mquKLBp+H06WTeGYEQh7OF5wa44IPHbh+qNdTP15xSzxwISPml1xCweJ6DExDpDDxXe/P34wP+GdDrg==",
+			"requires": {
+				"es6-promise": "^4.1.1",
+				"isomorphic-fetch": "^2.2.1",
+				"source-map": "^0.6.1"
+			},
+			"dependencies": {
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+				}
+			}
+		},
 		"spdx-correct": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.0.tgz",
@@ -14444,7 +14821,6 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
 			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-			"dev": true,
 			"requires": {
 				"safe-buffer": "~5.1.0"
 			}
@@ -14996,7 +15372,6 @@
 			"version": "1.6.18",
 			"resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
 			"integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
-			"dev": true,
 			"requires": {
 				"media-typer": "0.3.0",
 				"mime-types": "~2.1.24"
@@ -15005,8 +15380,7 @@
 		"typedarray": {
 			"version": "0.0.6",
 			"resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-			"integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
-			"dev": true
+			"integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
 		},
 		"typescript": {
 			"version": "3.7.4",
@@ -15018,7 +15392,6 @@
 			"version": "3.4.10",
 			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.4.10.tgz",
 			"integrity": "sha512-Y2VsbPVs0FIshJztycsO2SfPk7/KAF/T72qzv9u5EpQ4kB2hQoHlhNQTsNyy6ul7lQtqJN/AoWeS23OzEiEFxw==",
-			"dev": true,
 			"requires": {
 				"commander": "~2.19.0",
 				"source-map": "~0.6.1"
@@ -15027,14 +15400,12 @@
 				"commander": {
 					"version": "2.19.0",
 					"resolved": "https://registry.npmjs.org/commander/-/commander-2.19.0.tgz",
-					"integrity": "sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg==",
-					"dev": true
+					"integrity": "sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg=="
 				},
 				"source-map": {
 					"version": "0.6.1",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
 				}
 			}
 		},
@@ -15117,8 +15488,7 @@
 		"unpipe": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
-			"integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
-			"dev": true
+			"integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
 		},
 		"unquote": {
 			"version": "1.1.1",
@@ -15175,8 +15545,7 @@
 		"upper-case": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/upper-case/-/upper-case-1.1.3.tgz",
-			"integrity": "sha1-9rRQHC7EzdJrp4vnIilh3ndiFZg=",
-			"dev": true
+			"integrity": "sha1-9rRQHC7EzdJrp4vnIilh3ndiFZg="
 		},
 		"uri-js": {
 			"version": "4.2.2",
@@ -15258,8 +15627,7 @@
 		"util-deprecate": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-			"dev": true
+			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
 		},
 		"util.promisify": {
 			"version": "1.0.0",
@@ -15280,8 +15648,7 @@
 		"utils-merge": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
-			"integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=",
-			"dev": true
+			"integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
 		},
 		"uuid": {
 			"version": "3.3.2",
@@ -15308,8 +15675,7 @@
 		"vary": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
-			"integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=",
-			"dev": true
+			"integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
 		},
 		"vendors": {
 			"version": "1.0.3",
@@ -15837,8 +16203,7 @@
 		"whatwg-fetch": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz",
-			"integrity": "sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q==",
-			"dev": true
+			"integrity": "sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q=="
 		},
 		"whatwg-mimetype": {
 			"version": "2.3.0",
@@ -16119,8 +16484,7 @@
 		"wrappy": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-			"dev": true
+			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
 		},
 		"write": {
 			"version": "1.0.3",
@@ -16256,6 +16620,14 @@
 			"requires": {
 				"camelcase": "^5.0.0",
 				"decamelize": "^1.2.0"
+			}
+		},
+		"yauzl": {
+			"version": "2.4.1",
+			"resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.4.1.tgz",
+			"integrity": "sha1-lSj0QtqxsihOWLQ3m7GU4i4MQAU=",
+			"requires": {
+				"fd-slicer": "~1.0.1"
 			}
 		},
 		"yazl": {

--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -5,11 +5,13 @@
   "dependencies": {
     "emotion": "^10.0.27",
     "react": "^16.12.0",
-    "react-dom": "^16.12.0"
+    "react-dom": "^16.12.0",
+    "react-snap": "^1.23.0"
   },
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",
+    "postbuild": "react-snap",
     "eject": "react-scripts eject"
   },
   "eslintConfig": {
@@ -41,5 +43,8 @@
     "react-scripts": "^3.3.0",
     "typescript": "^3.7.4",
     "yazl": "^2.5.1"
+  },
+  "reactSnap": {
+    "inlineCss": true
   }
 }

--- a/packages/website/public/index.html
+++ b/packages/website/public/index.html
@@ -22,7 +22,6 @@
     <title>kgarsjo</title>
   </head>
   <body>
-    <noscript>You need to enable JavaScript to run this app.</noscript>
     <div id="root"></div>
     <!--
       This HTML file is a template.

--- a/packages/website/src/components/App/index.tsx
+++ b/packages/website/src/components/App/index.tsx
@@ -7,6 +7,13 @@ html, body {
     color: #eee;
 }
 
+noscript {
+    background-color: #a42f2f;
+    display: block;
+    margin: 1em 0;
+    padding: 1em;
+}
+
 a:link { color: #b8f5f0; }
 a:visited { color: #39ada3; }
 `;
@@ -22,6 +29,7 @@ const App = () => (
     <Fragment>
         <h1>Kevin Garsjo</h1>
         <h2>Software Engineer</h2>
+        <noscript>Enabling javascript is recommended but not required</noscript>
         <p>{emojiIcon('🏢', 'work')}SDE2 at Amazon</p>
         <p>{emojiIcon('🏠', 'home')}{"Living in Portland, OR"}</p>
         <p>{emojiIcon('🎓', 'education')}{"Bachelors of Science, CompSci, Universiy of Oregon"}</p>

--- a/packages/website/src/index.tsx
+++ b/packages/website/src/index.tsx
@@ -2,4 +2,6 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import App from './components/App';
 
-ReactDOM.render(<App />, document.getElementById('root'));
+const rootElement = document.getElementById('root');
+const render = rootElement?.hasChildNodes() ? ReactDOM.hydrate : ReactDOM.render;
+render(<App />, rootElement);


### PR DESCRIPTION
This PR...
- Generates static HTML for all the pages present in the webapp (currently just `/`)
- Moves the `noscript` messaging it within-app (since it's now being statically generated) with styling