### PR TITLE
[feat] Create and use an ACM certificate

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,6 +24,7 @@ jobs:
             export AWS_ACCESS_KEY_ID=$BETA_AWS_ACCESS_KEY_ID
             export AWS_SECRET_ACCESS_KEY=$BETA_AWS_SECRET_ACCESS_KEY
             npm run deploy
+          no_output_timeout: "1h"
 
   deploy-prod:
     docker:
@@ -38,6 +39,7 @@ jobs:
             export AWS_ACCESS_KEY_ID=$PROD_AWS_ACCESS_KEY_ID
             export AWS_SECRET_ACCESS_KEY=$PROD_AWS_SECRET_ACCESS_KEY
             npm run deploy
+          no_output_timeout: "1h"
 workflows:
   version: 2
   build-and-deploy:

--- a/deploy.sslcert.config.json
+++ b/deploy.sslcert.config.json
@@ -1,0 +1,16 @@
+{
+    "strategy": "aws-cfn",
+    "bucket": {
+        "fromExport": "BuildOutputBucketName"
+    },
+    "artifacts": [],
+    "stacks": [
+        {
+            "name": "KgarsjoComSSLCertStack",
+            "artifactNamesConsumed": [],
+            "capabilities": [],
+            "parameters": {},
+            "templatePath": "packages/infrastructure/build/SSLCertStack.template.json"
+        }
+    ]
+}

--- a/packages/infrastructure/lib/AppStack/index.ts
+++ b/packages/infrastructure/lib/AppStack/index.ts
@@ -1,16 +1,21 @@
 import { App, Stack, CfnParameter } from '@aws-cdk/core';
 import Website from '../Constructs/Website';
 import { Bucket } from '@aws-cdk/aws-s3';
+import AccountIDConfiguration, { AccountIDConfigMap } from '../Constructs/AccountIDConfiguration';
 
 export interface AppStackConfig {
-    budgetSubscriberEmail: string,
+    accountIDConfiguration: AccountIDConfigMap,
 }
 
 export default class AppStack extends Stack {
-    constructor(scope: App, name: string) {
+    constructor(scope: App, name: string, props: AppStackConfig) {
         super(scope, name);
+        
+        const accountIDConfig = new AccountIDConfiguration(this, props.accountIDConfiguration);
 
         new Website(this, {
+            domainName: accountIDConfig.getDomainName(),
+            sslCertificateARN: accountIDConfig.getSSLCertificateArn(),
             unzipperLambdaBucket: Bucket.fromBucketName(this, 'UnzipperLambdaBucket',
                 new CfnParameter(this, 'UnzipperLambdaArtifactBucket', {
                     type: 'String',

--- a/packages/infrastructure/lib/Constructs/AccountIDConfiguration.ts
+++ b/packages/infrastructure/lib/Constructs/AccountIDConfiguration.ts
@@ -1,0 +1,25 @@
+import { Construct, CfnMapping, Aws } from "@aws-cdk/core";
+
+export type AccountIDConfigMap = { [accountID: string]: {
+    domainName: string,
+    sslCertificateARN: string
+}};
+
+export default class AccountIDConfiguration extends Construct {
+    private accountIDConfigMapping: CfnMapping
+
+    constructor(scope: Construct, accountIDConfiguration: AccountIDConfigMap) {
+        super(scope, 'AccountIDConfiguration');
+        this.accountIDConfigMapping =  new CfnMapping(this, 'Mapping', {
+            mapping: accountIDConfiguration,
+        });
+    }
+
+    getDomainName() {
+        return this.accountIDConfigMapping.findInMap(Aws.ACCOUNT_ID, 'domainName');
+    }
+    
+    getSSLCertificateArn() {
+        return this.accountIDConfigMapping.findInMap(Aws.ACCOUNT_ID, 'sslCertificateARN');
+    }
+}

--- a/packages/infrastructure/lib/SSLCertStack/index.ts
+++ b/packages/infrastructure/lib/SSLCertStack/index.ts
@@ -1,0 +1,31 @@
+import { Stack, App, CfnOutput } from "@aws-cdk/core";
+import { Certificate, ValidationMethod } from "@aws-cdk/aws-certificatemanager";
+import AccountIDConfiguration, { AccountIDConfigMap } from "../Constructs/AccountIDConfiguration";
+
+interface SSLCertStackProps {
+    accountIDConfiguration: AccountIDConfigMap,
+}
+
+/**
+ * This stack must be deployed in the us-east-1 region to be usable by CloudFront
+ */
+export default class SSLCertStack extends Stack {
+    constructor(scope: App,name: string, props: SSLCertStackProps) {
+        super(scope, name);
+        const accountIDConfig = new AccountIDConfiguration(this, props.accountIDConfiguration);
+        const domainName = accountIDConfig.getDomainName();
+
+        const sslCertificate = new Certificate(this, 'SSLCertificate', {
+            domainName,
+            validationDomains: {
+                [domainName]: 'kgarsjo.com',
+            },
+            validationMethod: ValidationMethod.DNS,
+        });
+
+        new CfnOutput(this, 'SSLCertificateARN', {
+            value: sslCertificate.certificateArn,
+            exportName: 'SSLCertificateARN',
+        });
+    }
+}

--- a/packages/infrastructure/lib/index.ts
+++ b/packages/infrastructure/lib/index.ts
@@ -4,6 +4,7 @@ import AppStack from './AppStack';
 import BootstrapStack from './Constructs/BootstrapStack';
 import BudgetStack from './Constructs/BudgetStack';
 import { TimeUnit, BudgetType } from './Constructs/Budget';
+import SSLCertStack from './SSLCertStack';
 
 const config = {
     budgetLimit: {
@@ -13,10 +14,21 @@ const config = {
     budgetTimeUnit: TimeUnit.MONTHLY,
     budgetType: BudgetType.COST,
     budgetSubscriberEmail: 'krgarsjo@gmail.com',
+    accountIDConfiguration: {
+        '144053636142': {   // kgarsjocom-beta
+            domainName: 'beta.kgarsjo.com',
+            sslCertificateARN: 'arn:aws:acm:us-east-1:144053636142:certificate/0f8f3cbb-19aa-4fb2-924c-c0c727e11378',
+        },
+        '901675770819': {   // kgarsjocom-prod
+            domainName: 'www.kgarsjo.com',
+            sslCertificateARN: 'arn:aws:acm:us-east-1:901675770819:certificate/b6544272-4c30-4ddf-bea2-ce83ac4da2fc',
+        },
+    },
     projectName: 'KgarsjoCom',
 };
 
 const app = new App();
 new BootstrapStack(app, 'BootstrapStack', config);
 new BudgetStack(app, 'BudgetStack', config);
-new AppStack(app, 'AppStack');
+new SSLCertStack(app, 'SSLCertStack', config);
+new AppStack(app, 'AppStack', config);

--- a/packages/infrastructure/package-lock.json
+++ b/packages/infrastructure/package-lock.json
@@ -355,6 +355,12 @@
 			"integrity": "sha512-zwrxviZS08kRX40nqBrmERElF2vpw4IUTd5khkhBTfFH8AOaeoLVx48EC4+ZzS2/Iga7NevncqnsUSYjM4OWYA==",
 			"dev": true
 		},
+		"@types/once": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/@types/once/-/once-1.4.0.tgz",
+			"integrity": "sha512-cnEvTAVVRqF6OQg/4SLnbxQ0slZJHqZQDve5BzGhcIQtuMpPv8T5QNS2cBPa/W0jTxciqwn7bmJAIGe/bOJ5Kw==",
+			"dev": true
+		},
 		"agent-base": {
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.3.0.tgz",

--- a/packages/infrastructure/package.json
+++ b/packages/infrastructure/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "@aws-cdk/aws-apigateway": "^1.19.0",
     "@aws-cdk/aws-budgets": "^1.19.0",
+    "@aws-cdk/aws-certificatemanager": "^1.19.0",
     "@aws-cdk/aws-cloudfront": "^1.19.0",
     "@aws-cdk/aws-cloudwatch": "^1.19.0",
     "@aws-cdk/core": "^1.19.0",


### PR DESCRIPTION
This PR creates a standalone `SSLCertStack` which defines an ACM certificate. This certificate must be deployed to `us-east-1` to be usable by CloudFront, regardless of where the CloudFront distribution is deployed. It also must validate ownership of the domain, requiring manual steps.

For these reasons, the cert was placed in a standalone stack, which is intended to be deployed before the `AppStack`.

The SSL cert allows CloudFront to respond with a 200 status to requests whose origin is not CloudFront, e.g. `beta.kgarsjo.com` or `www.kgarsjo.com`.